### PR TITLE
fix: 모바일에서 MDX 테이블이 한 글자씩 wrap되는 회귀 차단 (#36)

### DIFF
--- a/src/shared/components/mdx/MdxTable.tsx
+++ b/src/shared/components/mdx/MdxTable.tsx
@@ -7,7 +7,7 @@ type MdxTableProps = ComponentProps<"table">;
 export function MdxTable({ className, ...rest }: MdxTableProps) {
 	return (
 		<div className="border-border-subtle my-6 overflow-x-auto rounded-md border">
-			<table className={cn("w-full text-left text-sm", className)} {...rest} />
+			<table className={cn("min-w-full text-left text-sm", className)} {...rest} />
 		</div>
 	);
 }

--- a/src/shared/styles/prose.css
+++ b/src/shared/styles/prose.css
@@ -138,7 +138,6 @@
 }
 
 .prose table {
-	width: 100%;
 	border-collapse: collapse;
 	font-size: 0.9375rem;
 }
@@ -148,6 +147,9 @@
 	padding: 0.75em 1em;
 	text-align: left;
 	border-bottom: 1px solid var(--color-border-subtle);
+	min-width: 8rem;
+	word-break: keep-all;
+	overflow-wrap: anywhere;
 }
 
 .prose th {


### PR DESCRIPTION
## 변경 사항

- `MdxTable.tsx`의 `<table>` 클래스 `w-full` → `min-w-full` 변경 (wrapper가 폭 결정)
- `.prose table { width: 100% }` 제거, `.prose th, .prose td`에 `min-width: 8rem` + `word-break: keep-all` + `overflow-wrap: anywhere` 적용
- 발생 조건: 4컬럼 + 짧은 헤더(≤3자) + 긴 인라인 코드 셀 동반 시 CSS auto table-layout이 짧은 헤더 컬럼을 43px까지 압축 → 한국어가 음절 단위로 한 글자씩 wrap

closes #36

## 관련 문서

해당 없음 — 렌더링 레이어 버그 픽스

## 테스트

- [x] `pnpm lint` 통과 (lefthook pre-commit hook으로 자동 검증)
- [x] `pnpm build` 성공 (24개 포스트 SSG 정상)
- [x] 개발 서버에서 동작 확인 (5개 뷰포트 × 12개 포스트 × 44+개 테이블 sweep, 회귀 0건)
- [x] 가로 스크롤 끝점 도달 가능 확인 (iPhone SE 375px에서 마지막 셀 viewportFit: true)

---

**머지 정책**: merge commit 또는 rebase merge로 머지 부탁드립니다 (squash 금지 — `.claude/rules/workflow.md`)
